### PR TITLE
Decide import branch by type info

### DIFF
--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -177,7 +177,7 @@ func (c *crdResource) Delete(ctx context.Context, req tfresource.DeleteRequest, 
 }
 
 func (c *crdResource) ImportState(ctx context.Context, req tfresource.ImportStateRequest, resp *tfresource.ImportStateResponse) {
-	if strings.Contains(req.ID, "/") {
+	if c.typeInfo.Namespaced {
 		components := strings.SplitN(req.ID, "/", 2)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("metadata").AtName("namespace"), components[0])...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("metadata").AtName("name"), components[1])...)


### PR DESCRIPTION
This avoids confusion where the user passes `namespace/name` to a non-namespaced resource.