### PR TITLE
Create functions to parse CRDs

### DIFF
--- a/internal/provider/crd/data_source_test.go
+++ b/internal/provider/crd/data_source_test.go
@@ -51,9 +51,10 @@ func TestAccDataSource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:          string(cfg),
-				ConfigVariables: config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
-				Check:           makeChecks(k, checkSpec),
+				Config:            string(cfg),
+				ConfigVariables:   config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
+				Check:             makeChecks(k, checkSpec.Resources),
+				ConfigStateChecks: makeStateChecks(checkSpec.Properties),
 			},
 		},
 	})

--- a/internal/provider/crd/fixtures/core/data-test.json
+++ b/internal/provider/crd/fixtures/core/data-test.json
@@ -2,17 +2,17 @@
     "Properties": [
         {
             "Name": "data.k8scrd_deployment_apps_v1.foo",
-            "Path": "spec.replicas",
-            "Value": "0"
+            "Path": ["spec", "replicas"],
+            "Value": 0
         },
         {
             "Name": "data.k8scrd_configmap_v1.foo",
-            "Path": "data.foo.txt",
+            "Path": ["data", "foo.txt"],
             "Value": "hello, world!\n"
         },
         {
             "Name": "data.k8scrd_namespace_v1.foo",
-            "Path": "metadata.name",
+            "Path": ["metadata", "name"],
             "Value": "foo"
         }
     ]

--- a/internal/provider/crd/fixtures/core/fn-test.json
+++ b/internal/provider/crd/fixtures/core/fn-test.json
@@ -1,0 +1,9 @@
+{
+    "Outputs": [
+        {
+            "Name": "pod",
+            "Path": ["spec", "containers", 0, "image"],
+            "Value": "ubuntu:22.04"
+        }
+    ]
+}

--- a/internal/provider/crd/fixtures/core/fn.tf
+++ b/internal/provider/crd/fixtures/core/fn.tf
@@ -1,0 +1,20 @@
+variable "kubeconfig" {
+  type      = string
+  sensitive = true
+}
+
+provider "k8scrd" {
+  kubeconfig = var.kubeconfig
+}
+
+output "pod" {
+  value = provider::k8scrd::parse_pod_v1({
+    apiVersion = "v1"
+    kind       = "Pod"
+    metadata = {
+      name      = "bar"
+      namespace = "default"
+    }
+    spec = { containers = [{ name : "ubuntu", image : "ubuntu:22.04" }] }
+  })
+}

--- a/internal/provider/crd/fixtures/core/resources-test.json
+++ b/internal/provider/crd/fixtures/core/resources-test.json
@@ -2,37 +2,37 @@
     "Properties": [
         {
             "Name": "k8scrd_configmap_v1.bar",
-            "Path": "data.foo.txt",
+            "Path": ["data", "foo.txt"],
             "Value": "bar"
         },
         {
             "Name": "k8scrd_deployment_apps_v1.bar",
-            "Path": "spec.replicas",
-            "Value": "0"
+            "Path": ["spec", "replicas"],
+            "Value": 0
         },
         {
             "Name": "k8scrd_deployment_apps_v1.bar",
-            "Path": "spec.strategy.rolling_update.max_unavailable",
-            "Value": "1"
+            "Path": ["spec", "strategy", "rolling_update", "max_unavailable"],
+            "Value": 1
         },
         {
             "Name": "k8scrd_deployment_apps_v1.baz",
-            "Path": "spec.replicas",
-            "Value": "0"
+            "Path": ["spec", "replicas"],
+            "Value": 0
         },
         {
             "Name": "k8scrd_namespace_v1.bar",
-            "Path": "metadata.name",
+            "Path": ["metadata", "name"],
             "Value": "bar"
         },
         {
             "Name": "k8scrd_namespace_v1.baz",
-            "Path": "metadata.name",
+            "Path": ["metadata", "name"],
             "Value": "baz"
         },
         {
             "Name": "k8scrd_clusterrole_rbac_authorization_k8s_io_v1.bar",
-            "Path": "rules.0.verbs.0",
+            "Path": ["rules", 0, "verbs", 0],
             "Value": "get"
         }
     ],

--- a/internal/provider/crd/fixtures/example.com/data-test.json
+++ b/internal/provider/crd/fixtures/example.com/data-test.json
@@ -2,7 +2,7 @@
     "Properties": [
         {
             "Name": "data.k8scrd_foo_example_com_v1.foo",
-            "Path": "spec.foo",
+            "Path": ["spec", "foo"],
             "Value": "foo"
         }
     ]

--- a/internal/provider/crd/fixtures/example.com/fn-test.json
+++ b/internal/provider/crd/fixtures/example.com/fn-test.json
@@ -1,0 +1,9 @@
+{
+    "Outputs": [
+        {
+            "Name": "foo",
+            "Path": ["spec", "foo"],
+            "Value": "bar"
+        }
+    ]
+}

--- a/internal/provider/crd/fixtures/example.com/fn.tf
+++ b/internal/provider/crd/fixtures/example.com/fn.tf
@@ -1,0 +1,20 @@
+variable "kubeconfig" {
+  type      = string
+  sensitive = true
+}
+
+provider "k8scrd" {
+  kubeconfig = var.kubeconfig
+}
+
+locals {
+  pod = provider::k8scrd::parse_foo_example_com_v1({
+    apiVersion = "example.com/v1"
+    kind = "Foo"
+    metadata = {
+      name      = "bar"
+      namespace = "default"
+    }
+    spec = { foo = "bar" }
+  })
+}

--- a/internal/provider/crd/fixtures/example.com/fn.tf
+++ b/internal/provider/crd/fixtures/example.com/fn.tf
@@ -7,8 +7,8 @@ provider "k8scrd" {
   kubeconfig = var.kubeconfig
 }
 
-locals {
-  pod = provider::k8scrd::parse_foo_example_com_v1({
+output "foo" {
+  value = provider::k8scrd::parse_foo_example_com_v1({
     apiVersion = "example.com/v1"
     kind = "Foo"
     metadata = {

--- a/internal/provider/crd/fixtures/example.com/resources-test.json
+++ b/internal/provider/crd/fixtures/example.com/resources-test.json
@@ -2,12 +2,12 @@
     "Properties": [
         {
             "Name": "k8scrd_foo_example_com_v1.bar",
-            "Path": "spec.foo",
+            "Path": ["spec", "foo"],
             "Value": "bar"
         },
         {
             "Name": "k8scrd_bar_example_com_v1.bar",
-            "Path": "spec.bar",
+            "Path": ["spec", "bar"],
             "Value": "bar"
         }
     ],

--- a/internal/provider/crd/function_parse_yaml.go
+++ b/internal/provider/crd/function_parse_yaml.go
@@ -1,0 +1,159 @@
+package crd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/generic"
+)
+
+var _ function.Function = &ParseYAMLFunction{}
+
+type ParseYAMLFunction struct {
+	typeInfo generic.TypeInfo
+}
+
+func NewParseYAMLFunction(typeInfo generic.TypeInfo) function.Function {
+	return &ParseYAMLFunction{typeInfo}
+}
+
+func (f *ParseYAMLFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	groupComponents := []string{}
+	if f.typeInfo.Group != "" {
+		groupComponents = strings.Split(f.typeInfo.Group, ".")
+	}
+	nameComponents := []string{"parse", strings.ToLower(f.typeInfo.Kind)}
+	nameComponents = append(nameComponents, groupComponents...)
+	nameComponents = append(nameComponents, f.typeInfo.Version)
+	resp.Name = strings.Join(nameComponents, "_")
+}
+
+func (f *ParseYAMLFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:     "Parse a multi-document YAML function into an array of objects",
+		Description: "Given a multi-document YAML, parse it into an array of Kubernetes objects.",
+
+		Parameters: []function.Parameter{
+			function.DynamicParameter{
+				Name:        "yaml",
+				Description: "YAML document to parse",
+			},
+		},
+		Return: function.ObjectReturn{
+			AttributeTypes: f.typeInfo.Schema.AttrTypes,
+			CustomType:     f.typeInfo.Schema,
+		},
+	}
+}
+
+func (f *ParseYAMLFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var yaml basetypes.DynamicValue
+
+	resp.Error = req.Arguments.Get(ctx, &yaml)
+	if resp.Error != nil {
+		return
+	}
+
+	obj, diags := toUnstructured(yaml.UnderlyingValue(), path.Empty())
+	if diags.HasError() {
+		resp.Error = function.FuncErrorFromDiags(ctx, diags)
+		return
+	}
+
+	value, valueDiags := f.typeInfo.Schema.ValueFromUnstructured(ctx, path.Empty(), nil, obj)
+	diags.Append(valueDiags...)
+	if diags.HasError() {
+		resp.Error = function.FuncErrorFromDiags(ctx, diags)
+		return
+	}
+
+	resp.Error = resp.Result.Set(ctx, value)
+}
+
+func toUnstructured(obj attr.Value, path path.Path) (interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	switch v := obj.(type) {
+	case basetypes.ObjectValue:
+		attrs := v.Attributes()
+		unstructured := make(map[string]interface{}, len(attrs))
+		for k, v := range attrs {
+			attrPath := path.AtName(k)
+			attr, attrDiags := toUnstructured(v, attrPath)
+			diags.Append(attrDiags...)
+			if !attrDiags.HasError() {
+				unstructured[k] = attr
+			}
+		}
+		return unstructured, diags
+	case basetypes.TupleValue:
+		elems := v.Elements()
+		unstructured := make([]interface{}, 0, len(elems))
+		for i, v := range elems {
+			elemPath := path.AtTupleIndex(i)
+			elem, elemDiags := toUnstructured(v, elemPath)
+			diags.Append(elemDiags...)
+			if !elemDiags.HasError() {
+				unstructured = append(unstructured, elem)
+			}
+		}
+		return unstructured, diags
+	case basetypes.ListValue:
+		elems := v.Elements()
+		unstructured := make([]interface{}, 0, len(elems))
+		for i, v := range elems {
+			elemPath := path.AtListIndex(i)
+			elem, elemDiags := toUnstructured(v, elemPath)
+			diags.Append(elemDiags...)
+			if !elemDiags.HasError() {
+				unstructured = append(unstructured, elem)
+			}
+		}
+		return unstructured, diags
+	case basetypes.MapValue:
+		elems := v.Elements()
+		unstructured := make(map[string]interface{}, len(elems))
+		for k, v := range elems {
+			attrPath := path.AtMapKey(k)
+			attr, attrDiags := toUnstructured(v, attrPath)
+			diags.Append(attrDiags...)
+			if !attrDiags.HasError() {
+				unstructured[k] = attr
+			}
+		}
+		return unstructured, diags
+	case basetypes.SetValue:
+		elems := v.Elements()
+		unstructured := make([]interface{}, 0, len(elems))
+		for _, v := range elems {
+			elemPath := path.AtSetValue(v)
+			elem, elemDiags := toUnstructured(v, elemPath)
+			diags.Append(elemDiags...)
+			if !elemDiags.HasError() {
+				unstructured = append(unstructured, elem)
+			}
+		}
+		return unstructured, diags
+	case basetypes.StringValue:
+		return v.ValueString(), diags
+	case basetypes.NumberValue:
+		f := v.ValueBigFloat()
+		if f.IsInt() {
+			i, _ := f.Int64()
+			return i, diags
+		} else {
+			f, _ := f.Float64()
+			return f, diags
+		}
+	case basetypes.BoolValue:
+		return v.ValueBool(), diags
+	default:
+		diags.Append(diag.NewAttributeErrorDiagnostic(path, "Unsupported dynamic value type", fmt.Sprintf("got %T", v)))
+		return nil, diags
+	}
+}

--- a/internal/provider/crd/function_parse_yaml_test.go
+++ b/internal/provider/crd/function_parse_yaml_test.go
@@ -1,0 +1,67 @@
+package crd_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/provider/crd"
+)
+
+func TestAccFn(t *testing.T) {
+	kubeconfig, err := os.ReadFile(os.Getenv("KUBECONFIG"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	providerFactory, err := crd.New("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawCheckSpec, err := os.ReadFile(fmt.Sprintf("fixtures/%s/resources-test.json", os.Getenv("PROVIDER")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var checkSpeck checkSpec
+	err = json.Unmarshal(rawCheckSpec, &checkSpeck)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/fn.tf", os.Getenv("PROVIDER")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"k8scrd": providerserver.NewProtocol6WithError(providerFactory()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:          string(cfg),
+				ConfigVariables: config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownOutputValue(
+							"pod",
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"metadata": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+									"name": knownvalue.StringExact("bar"),
+								}),
+							}),
+						),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/crd/function_parse_yaml_test.go
+++ b/internal/provider/crd/function_parse_yaml_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/provider/crd"
 )
 
@@ -26,7 +24,7 @@ func TestAccFn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rawCheckSpec, err := os.ReadFile(fmt.Sprintf("fixtures/%s/resources-test.json", os.Getenv("PROVIDER")))
+	rawCheckSpec, err := os.ReadFile(fmt.Sprintf("fixtures/%s/fn-test.json", os.Getenv("PROVIDER")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,20 +45,9 @@ func TestAccFn(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:          string(cfg),
-				ConfigVariables: config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownOutputValue(
-							"pod",
-							knownvalue.ObjectPartial(map[string]knownvalue.Check{
-								"metadata": knownvalue.ObjectPartial(map[string]knownvalue.Check{
-									"name": knownvalue.StringExact("bar"),
-								}),
-							}),
-						),
-					},
-				},
+				Config:           string(cfg),
+				ConfigVariables:  config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
+				ConfigPlanChecks: makeConfigChecks(checkSpeck.Properties, checkSpeck.Outputs),
 			},
 		},
 	})

--- a/internal/provider/crd/provider.go
+++ b/internal/provider/crd/provider.go
@@ -78,7 +78,11 @@ func (p *CrdProvider) Resources(context.Context) []func() resource.Resource {
 }
 
 func (p *CrdProvider) Functions(context.Context) []func() function.Function {
-	return []func() function.Function{}
+	result := make([]func() function.Function, 0, len(p.typeInfos))
+	for _, typeInfo := range p.typeInfos {
+		result = append(result, func() function.Function { return NewParseYAMLFunction(typeInfo) })
+	}
+	return result
 }
 
 func New(version string) (func() tfprovider.Provider, error) {

--- a/internal/provider/crd/provider_test.go
+++ b/internal/provider/crd/provider_test.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeschema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,8 +57,8 @@ func checkNotExists(client *dynamic.DynamicClient, gvr metav1.GroupVersionResour
 
 type checkProperty struct {
 	Name  string
-	Path  string
-	Value string
+	Path  []interface{}
+	Value interface{}
 }
 
 type checkResource struct {
@@ -67,19 +71,77 @@ type checkSpec struct {
 	Properties []checkProperty
 }
 
-func makeChecks(client *dynamic.DynamicClient, spec checkSpec) resource.TestCheckFunc {
-	checks := make([]resource.TestCheckFunc, 0, len(spec.Resources)+len(spec.Properties))
-
-	for _, resource := range spec.Resources {
-		check := checkExists(client, resource.GroupVersionResource, resource.Metadata)
-		checks = append(checks, check)
+func parsePath(path []interface{}) tfjsonpath.Path {
+	var out tfjsonpath.Path
+	switch start := path[0].(type) {
+	case string:
+		out = tfjsonpath.New(start)
+	case int:
+		out = tfjsonpath.New(start)
+	default:
+		panic("Unsupported path type!")
 	}
-	for _, property := range spec.Properties {
-		check := resource.TestCheckResourceAttr(property.Name, property.Path, property.Value)
+
+	for _, p := range path[1:] {
+		switch p := p.(type) {
+		case string:
+			out = out.AtMapKey(p)
+		case int:
+			out = out.AtSliceIndex(p)
+		case float64:
+			out = out.AtSliceIndex(int(p))
+		default:
+			panic("unsupported path type")
+		}
+	}
+
+	return out
+}
+
+func parseValue(value interface{}) knownvalue.Check {
+	switch value := value.(type) {
+	case string:
+		return knownvalue.StringExact(value)
+	case int64:
+		return knownvalue.Int64Exact(value)
+	case float64:
+		return knownvalue.Float64Exact(value)
+	default:
+		panic("unsupported value type")
+	}
+}
+
+func makeChecks(client *dynamic.DynamicClient, spec []checkResource) resource.TestCheckFunc {
+	checks := make([]resource.TestCheckFunc, 0, len(spec))
+
+	for _, resource := range spec {
+		check := checkExists(client, resource.GroupVersionResource, resource.Metadata)
 		checks = append(checks, check)
 	}
 
 	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func makeConfigChecks(spec []checkProperty) resource.ConfigPlanChecks {
+	checks := make([]plancheck.PlanCheck, 0, len(spec))
+
+	for _, property := range spec {
+		check := plancheck.ExpectKnownValue(property.Name, parsePath(property.Path), parseValue(property.Value))
+		checks = append(checks, check)
+	}
+
+	return resource.ConfigPlanChecks{PostApplyPostRefresh: checks}
+}
+
+func makeStateChecks(spec []checkProperty) []statecheck.StateCheck {
+	checks := make([]statecheck.StateCheck, 0, len(spec))
+
+	for _, property := range spec {
+		check := statecheck.ExpectKnownValue(property.Name, parsePath(property.Path), parseValue(property.Value))
+		checks = append(checks, check)
+	}
+
+	return checks
 }
 
 func makeDestroyChecks(client *dynamic.DynamicClient, resources []checkResource) resource.TestCheckFunc {

--- a/internal/provider/crd/resource_test.go
+++ b/internal/provider/crd/resource_test.go
@@ -51,9 +51,10 @@ func TestAccResource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:          string(cfg),
-				ConfigVariables: config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
-				Check:           makeChecks(k, checkSpeck),
+				Config:           string(cfg),
+				ConfigVariables:  config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
+				Check:            makeChecks(k, checkSpeck.Resources),
+				ConfigPlanChecks: makeConfigChecks(checkSpeck.Properties),
 			},
 		},
 		CheckDestroy: makeDestroyChecks(k, checkSpeck.Resources),

--- a/internal/provider/crd/resource_test.go
+++ b/internal/provider/crd/resource_test.go
@@ -54,7 +54,7 @@ func TestAccResource(t *testing.T) {
 				Config:           string(cfg),
 				ConfigVariables:  config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
 				Check:            makeChecks(k, checkSpeck.Resources),
-				ConfigPlanChecks: makeConfigChecks(checkSpeck.Properties),
+				ConfigPlanChecks: makeConfigChecks(checkSpeck.Properties, checkSpeck.Outputs),
 			},
 		},
 		CheckDestroy: makeDestroyChecks(k, checkSpeck.Resources),

--- a/internal/provider/fn/function_parse_yaml_test.go
+++ b/internal/provider/fn/function_parse_yaml_test.go
@@ -53,25 +53,25 @@ func TestParseYaml(t *testing.T) {
 						knownvalue.ListExact(
 							[]knownvalue.Check{
 								knownvalue.ObjectPartial(map[string]knownvalue.Check{
-									"api_version": knownvalue.StringExact("cert-manager.io/v1"),
-									"kind":        knownvalue.StringExact("Certificate"),
+									"apiVersion": knownvalue.StringExact("cert-manager.io/v1"),
+									"kind":       knownvalue.StringExact("Certificate"),
 									"metadata": knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"name": knownvalue.StringExact("foo"),
 									}),
 									"spec": knownvalue.ObjectPartial(map[string]knownvalue.Check{
-										"dns_names": knownvalue.ListExact([]knownvalue.Check{
+										"dnsNames": knownvalue.ListExact([]knownvalue.Check{
 											knownvalue.StringExact("foo.example.com"),
 										}),
 									}),
 								}),
 								knownvalue.ObjectPartial(map[string]knownvalue.Check{
-									"api_version": knownvalue.StringExact("cert-manager.io/v1"),
-									"kind":        knownvalue.StringExact("Certificate"),
+									"apiVersion": knownvalue.StringExact("cert-manager.io/v1"),
+									"kind":       knownvalue.StringExact("Certificate"),
 									"metadata": knownvalue.ObjectPartial(map[string]knownvalue.Check{
 										"name": knownvalue.StringExact("bar"),
 									}),
 									"spec": knownvalue.ObjectPartial(map[string]knownvalue.Check{
-										"dns_names": knownvalue.ListExact([]knownvalue.Check{
+										"dnsNames": knownvalue.ListExact([]knownvalue.Check{
 											knownvalue.StringExact("bar.example.com"),
 										}),
 									}),

--- a/internal/types/object.go
+++ b/internal/types/object.go
@@ -346,9 +346,8 @@ func DynamicObjectFromUnstructured(ctx context.Context, path path.Path, val map[
 
 	attrValues := make(map[string]attr.Value, len(val))
 	attrTypes := make(map[string]attr.Type, len(val))
-	fieldNames := make(map[string]string, len(val))
 	for k, v := range val {
-		fieldName := strcase.SnakeCase(k)
+		fieldName := k
 		fieldPath := path.AtName(fieldName)
 		var attrValue attr.Value
 		var attrDiags diag.Diagnostics
@@ -365,21 +364,13 @@ func DynamicObjectFromUnstructured(ctx context.Context, path path.Path, val map[
 			continue
 		}
 
-		fieldNames[fieldName] = k
 		attrValues[fieldName] = attrValue
 		attrTypes[fieldName] = attrValue.Type(ctx)
 	}
-	typ := KubernetesObjectType{
-		ObjectType: basetypes.ObjectType{AttrTypes: attrTypes},
-		FieldNames: fieldNames,
-	}
-
 	obj, objDiags := basetypes.NewObjectValue(attrTypes, attrValues)
 	diags.Append(objDiags...)
 
-	kubernetesObj, objDiags := typ.ValueFromObject(ctx, obj)
-	diags.Append(objDiags...)
-	return kubernetesObj, diags
+	return obj, diags
 }
 
 func (v *KubernetesObjectValue) FillNulls(ctx context.Context, path path.Path, config attr.Value) diag.Diagnostics {


### PR DESCRIPTION
The current one-size-fits-all approach doesn't work, because we can't distinguish between object fields (need to be `snake_case`) and map entries (shouldn't be modified).