### PR TITLE
Null fieldmanager

### DIFF
--- a/internal/generic/state.go
+++ b/internal/generic/state.go
@@ -5,7 +5,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/types"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,19 +32,6 @@ func StateToValue(ctx context.Context, state PlanOrState, typeInfo TypeInfo) (ty
 	}
 	objectValue := value.(*types.KubernetesObjectValue)
 	return objectValue, diags
-}
-
-func FillNulls(ctx context.Context, value types.KubernetesValue, state PlanOrState) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	var stateValue basetypes.ObjectValue
-	diags.Append(state.Get(ctx, &stateValue)...)
-	if diags.HasError() {
-		return diags
-	}
-
-	diags.Append(value.FillNulls(ctx, path.Empty(), stateValue)...)
-	return diags
 }
 
 var defaultFields fieldpath.Set
@@ -84,5 +70,5 @@ func GetManagedFieldSet(in *unstructured.Unstructured, fieldManager string) (*fi
 		}
 	}
 	fieldSet = fieldSet.Union(&defaultFields)
-	return fieldSet.Leaves(), nil
+	return fieldSet, nil
 }

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -99,13 +99,17 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 	if diags.HasError() {
 		return
 	}
-	state, diags = generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields)
+	diags = state.ManagedFields(ctx, path.Empty(), fields, nil)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	state, diags = generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields.Leaves())
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
 	}
 
-	diags = generic.FillNulls(ctx, state, req.Plan)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
@@ -120,6 +124,11 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 	if c.typeInfo.Namespaced {
 		resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("metadata").AtName("namespace"), &namespace)...)
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state, diags := generic.StateToValue(ctx, req.State, c.typeInfo)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -139,14 +148,18 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 	if diags.HasError() {
 		return
 	}
-
-	state, diags := generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields)
+	diags = state.ManagedFields(ctx, path.Empty(), fields, nil)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
 	}
 
-	diags = generic.FillNulls(ctx, state, req.State)
+	state, diags = generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields.Leaves())
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
@@ -189,7 +202,13 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 	if diags.HasError() {
 		return
 	}
-	state, diags = generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields)
+	diags = state.ManagedFields(ctx, path.Empty(), fields, nil)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	state, diags = generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields.Leaves())
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -73,7 +73,12 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 		return
 	}
 
-	planObj, diags := generic.StateToObject(ctx, req.Plan, c.typeInfo)
+	state, diags := generic.StateToValue(ctx, req.Plan, c.typeInfo)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	planObj, diags := generic.ValueToUnstructured(ctx, state, c.typeInfo)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -89,7 +94,12 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 		return
 	}
 
-	state, diags := generic.ObjectToState(ctx, c.typeInfo.Schema, *obj, fieldManager)
+	fields, diags := generic.GetManagedFieldSet(obj, fieldManager)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	state, diags = generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
@@ -124,7 +134,13 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 		return
 	}
 
-	state, diags := generic.ObjectToState(ctx, c.typeInfo.Schema, *obj, fieldManager)
+	fields, diags := generic.GetManagedFieldSet(obj, fieldManager)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	state, diags := generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
@@ -149,7 +165,12 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		return
 	}
 
-	obj, diags := generic.StateToObject(ctx, req.Plan, c.typeInfo)
+	state, diags := generic.StateToValue(ctx, req.Plan, c.typeInfo)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	obj, diags := generic.ValueToUnstructured(ctx, state, c.typeInfo)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -163,7 +184,12 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		return
 	}
 
-	state, diags := generic.ObjectToState(ctx, c.typeInfo.Schema, *obj, fieldManager)
+	fields, diags := generic.GetManagedFieldSet(obj, fieldManager)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	state, diags = generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return

--- a/internal/types/map.go
+++ b/internal/types/map.go
@@ -68,6 +68,10 @@ func (t KubernetesMapType) ValueFromUnstructured(
 	obj interface{},
 ) (attr.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics
+	if obj == nil {
+		obj = make(map[string]interface{}, 0)
+	}
+
 	mapObj, ok := obj.(map[string]interface{})
 	if !ok {
 		diags.Append(diag.NewAttributeErrorDiagnostic(
@@ -197,43 +201,6 @@ func (v KubernetesMapValue) Type(ctx context.Context) attr.Type {
 	return KubernetesMapType{MapType: basetypes.MapType{ElemType: v.ElementType(ctx)}}
 }
 
-func (v *KubernetesMapValue) FillNulls(ctx context.Context, path path.Path, config attr.Value) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	var kubernetesConfig *KubernetesMapValue
-	switch config := config.(type) {
-	case basetypes.MapValue:
-		baseConfig, diags := v.Type(ctx).(KubernetesMapType).ValueFromMap(ctx, config)
-		if diags.HasError() {
-			return diags
-		}
-		kubernetesConfig = baseConfig.(*KubernetesMapValue)
-	case *KubernetesMapValue:
-		kubernetesConfig = config
-	default:
-		diags.Append(diag.NewAttributeErrorDiagnostic(
-			path, "Unexpected value type",
-			fmt.Sprintf("Expected MapValue, got %T", config),
-		))
-		return diags
-	}
-
-	configElements := kubernetesConfig.Elements()
-	if v.IsNull() && !kubernetesConfig.IsNull() && len(configElements) == 0 {
-		v.MapValue, diags = basetypes.NewMapValue(v.ElementType(ctx), map[string]attr.Value{})
-	} else if !v.IsNull() && kubernetesConfig.IsNull() && len(v.Elements()) == 0 {
-		v.MapValue = basetypes.NewMapNull(v.ElementType(ctx))
-	} else {
-		for k, v := range v.Elements() {
-			if kubernetesValue, ok := v.(KubernetesValue); ok {
-				kubernetesValue.FillNulls(ctx, path.AtMapKey(k), configElements[k])
-			}
-		}
-	}
-
-	return diags
-}
-
 func (v KubernetesMapValue) ManagedFields(ctx context.Context, path path.Path, fields *fieldpath.Set, pe *fieldpath.PathElement) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -256,4 +223,4 @@ func (v KubernetesMapValue) ManagedFields(ctx context.Context, path path.Path, f
 }
 
 var _ basetypes.MapValuable = KubernetesMapValue{}
-var _ KubernetesValue = &KubernetesMapValue{}
+var _ KubernetesValue = KubernetesMapValue{}

--- a/internal/types/one_of.go
+++ b/internal/types/one_of.go
@@ -139,6 +139,16 @@ func (v KubernetesUnionValue) FillNulls(ctx context.Context, path path.Path, con
 	return diags
 }
 
+func (v KubernetesUnionValue) ManagedFields(ctx context.Context, path path.Path, fields *fieldpath.Set, pe *fieldpath.PathElement) diag.Diagnostics {
+	val := v.DynamicValue.UnderlyingValue()
+	if kubernetesVal, ok := val.(KubernetesValue); ok {
+		return kubernetesVal.ManagedFields(ctx, path, fields, pe)
+	} else {
+		fields.Insert([]fieldpath.PathElement{*pe})
+		return nil
+	}
+}
+
 var _ basetypes.DynamicValuable = KubernetesUnionValue{}
 var _ KubernetesValue = KubernetesUnionValue{}
 

--- a/internal/types/one_of.go
+++ b/internal/types/one_of.go
@@ -131,14 +131,6 @@ func (v KubernetesUnionValue) Type(context.Context) attr.Type {
 	return KubernetesUnionType{Members: v.MemberTypes}
 }
 
-func (v KubernetesUnionValue) FillNulls(ctx context.Context, path path.Path, config attr.Value) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	// TODO
-
-	return diags
-}
-
 func (v KubernetesUnionValue) ManagedFields(ctx context.Context, path path.Path, fields *fieldpath.Set, pe *fieldpath.PathElement) diag.Diagnostics {
 	val := v.DynamicValue.UnderlyingValue()
 	if kubernetesVal, ok := val.(KubernetesValue); ok {


### PR DESCRIPTION
This uses fieldsets to track null fields we care about. k8s doesn't save fields set to null values (e.g. empty `volumes`) to the managed fields. However, we need to return these to not show a constant diff.

Therefore, we construct a fieldset that contains all of the fields in the state, and union it with the actual fieldset. Then, we return this value. This allows us to track the fields we care about in one place, rather than having to do a second pass to fill in nulls.

One possible issue is that we could miss if we are accidentally removed from the current set of field-managers. However, that seems unlikely. We could fix this up by making `ManagedFields` (optionally) only enter nullish fields.