### PR TITLE
Correctly show (no) changes on import

### DIFF
--- a/internal/provider/crd/fixtures/core/resources-import-test.json
+++ b/internal/provider/crd/fixtures/core/resources-import-test.json
@@ -1,0 +1,43 @@
+{
+    "Properties": [
+        {
+            "Name": "k8scrd_deployment_apps_v1.baz",
+            "Path": [
+                "spec",
+                "replicas"
+            ],
+            "Value": 0
+        },
+        {
+            "Name": "k8scrd_namespace_v1.baz",
+            "Path": [
+                "metadata",
+                "name"
+            ],
+            "Value": "baz"
+        }
+    ],
+    "Resources": [
+        {
+            "GroupVersionResource": {
+                "group": "apps",
+                "version": "v1",
+                "resource": "deployments"
+            },
+            "Metadata": {
+                "name": "baz",
+                "namespace": "default"
+            }
+        },
+        {
+            "GroupVersionResource": {
+                "group": "",
+                "version": "v1",
+                "resource": "namespaces"
+            },
+            "Metadata": {
+                "name": "baz"
+            }
+        }
+    ]
+}

--- a/internal/provider/crd/fixtures/core/resources-import.tf
+++ b/internal/provider/crd/fixtures/core/resources-import.tf
@@ -30,7 +30,7 @@ resource "k8scrd_deployment_apps_v1" "baz" {
 
 import {
   to = k8scrd_deployment_apps_v1.baz
-  id = "default/baz"
+  id = "kubectl:default/baz"
 }
 
 resource "k8scrd_namespace_v1" "baz" {
@@ -39,5 +39,5 @@ resource "k8scrd_namespace_v1" "baz" {
 
 import {
   to = k8scrd_namespace_v1.baz
-  id = "baz"
+  id = "kubectl:baz"
 }

--- a/internal/provider/crd/fixtures/core/resources-import.tf
+++ b/internal/provider/crd/fixtures/core/resources-import.tf
@@ -1,0 +1,43 @@
+variable "kubeconfig" {
+  type      = string
+  sensitive = true
+}
+
+provider "k8scrd" {
+  kubeconfig = var.kubeconfig
+}
+
+resource "k8scrd_deployment_apps_v1" "baz" {
+  metadata = {
+    name      = "baz"
+    namespace = "default"
+    labels    = { app = "baz" }
+  }
+  spec = {
+    replicas = 0
+    selector = { match_labels = { app = "baz" } }
+    template = {
+      metadata = { labels = { app = "baz" } }
+      spec = {
+        containers = [{
+          name  = "baz"
+          image = "busybox"
+        }]
+      }
+    }
+  }
+}
+
+import {
+  to = k8scrd_deployment_apps_v1.baz
+  id = "default/baz"
+}
+
+resource "k8scrd_namespace_v1" "baz" {
+  metadata = { name = "baz" }
+}
+
+import {
+  to = k8scrd_namespace_v1.baz
+  id = "baz"
+}

--- a/internal/provider/crd/fixtures/core/resources-test.json
+++ b/internal/provider/crd/fixtures/core/resources-test.json
@@ -16,19 +16,9 @@
             "Value": 1
         },
         {
-            "Name": "k8scrd_deployment_apps_v1.baz",
-            "Path": ["spec", "replicas"],
-            "Value": 0
-        },
-        {
             "Name": "k8scrd_namespace_v1.bar",
             "Path": ["metadata", "name"],
             "Value": "bar"
-        },
-        {
-            "Name": "k8scrd_namespace_v1.baz",
-            "Path": ["metadata", "name"],
-            "Value": "baz"
         },
         {
             "Name": "k8scrd_clusterrole_rbac_authorization_k8s_io_v1.bar",
@@ -61,33 +51,12 @@
         },
         {
             "GroupVersionResource": {
-                "group": "apps",
-                "version": "v1",
-                "resource": "deployments"
-            },
-            "Metadata": {
-                "name": "baz",
-                "namespace": "default"
-            }
-        },
-        {
-            "GroupVersionResource": {
                 "group": "",
                 "version": "v1",
                 "resource": "namespaces"
             },
             "Metadata": {
                 "name": "bar"
-            }
-        },
-        {
-            "GroupVersionResource": {
-                "group": "",
-                "version": "v1",
-                "resource": "namespaces"
-            },
-            "Metadata": {
-                "name": "baz"
             }
         },
         {

--- a/internal/provider/crd/fixtures/core/resources.tf
+++ b/internal/provider/crd/fixtures/core/resources.tf
@@ -44,46 +44,11 @@ resource "k8scrd_configmap_v1" "bar" {
   data = { "foo.txt" = "bar" }
 }
 
-resource "k8scrd_deployment_apps_v1" "baz" {
-  metadata = {
-    name      = "baz"
-    namespace = "default"
-    labels    = { app = "baz" }
-  }
-  spec = {
-    replicas = 0
-    selector = { match_labels = { app = "baz" } }
-    template = {
-      metadata = { labels = { app = "baz" } }
-      spec = {
-        containers = [{
-          name  = "baz"
-          image = "busybox"
-        }]
-      }
-    }
-  }
-}
-
-import {
-  to = k8scrd_deployment_apps_v1.baz
-  id = "default/baz"
-}
-
 resource "k8scrd_namespace_v1" "bar" {
   metadata = {
     name   = "bar"
     labels = { "bar" = "bar" }
   }
-}
-
-resource "k8scrd_namespace_v1" "baz" {
-  metadata = { name = "baz" }
-}
-
-import {
-  to = k8scrd_namespace_v1.baz
-  id = "baz"
 }
 
 resource "k8scrd_clusterrole_rbac_authorization_k8s_io_v1" "bar" {

--- a/internal/provider/crd/fixtures/example.com/data.yaml
+++ b/internal/provider/crd/fixtures/example.com/data.yaml
@@ -4,3 +4,10 @@ metadata:
   name: foo
 spec:
   foo: foo
+---
+apiVersion: example.com/v1
+kind: Foo
+metadata:
+  name: baz
+spec:
+  foo: baz

--- a/internal/provider/crd/fixtures/example.com/resources-import-test.json
+++ b/internal/provider/crd/fixtures/example.com/resources-import-test.json
@@ -1,0 +1,25 @@
+{
+    "Properties": [
+        {
+            "Name": "k8scrd_foo_example_com_v1.baz",
+            "Path": [
+                "spec",
+                "foo"
+            ],
+            "Value": "baz"
+        }
+    ],
+    "Resources": [
+        {
+            "GroupVersionResource": {
+                "group": "example.com",
+                "version": "v1",
+                "resource": "foos"
+            },
+            "Metadata": {
+                "name": "baz",
+                "namespace": "default"
+            }
+        }
+    ]
+}

--- a/internal/provider/crd/fixtures/example.com/resources-import.tf
+++ b/internal/provider/crd/fixtures/example.com/resources-import.tf
@@ -1,0 +1,21 @@
+variable "kubeconfig" {
+  type      = string
+  sensitive = true
+}
+
+provider "k8scrd" {
+  kubeconfig = var.kubeconfig
+}
+
+resource "k8scrd_foo_example_com_v1" "baz" {
+  metadata = {
+    name      = "baz"
+    namespace = "default"
+  }
+  spec = { foo = "baz" }
+}
+
+import {
+  to = k8scrd_foo_example_com_v1.baz
+  id = "default/baz"
+}

--- a/internal/provider/crd/fixtures/example.com/resources-import.tf
+++ b/internal/provider/crd/fixtures/example.com/resources-import.tf
@@ -17,5 +17,5 @@ resource "k8scrd_foo_example_com_v1" "baz" {
 
 import {
   to = k8scrd_foo_example_com_v1.baz
-  id = "default/baz"
+  id = "kubectl:default/baz"
 }

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -133,6 +133,7 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("metadata").AtName("field_manager"), fieldManager)...)
 }
 
 func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp *tfresource.ReadResponse) {

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -207,6 +207,7 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		resp.Diagnostics.AddError("Unable to create resource", err.Error())
 		return
 	}
+	resp.Private.SetKey(ctx, "import-field-managers", nil)
 
 	fields, diags := generic.GetManagedFieldSet(obj, fieldManager)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -207,6 +207,10 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		resp.Diagnostics.AddError("Unable to create resource", err.Error())
 		return
 	}
+
+	// TODO: Should we unset the existing field-manager? Should we
+	// unconditionally do that on import (currently, Update only runs if there
+	// are changes)?
 	resp.Private.SetKey(ctx, "import-field-managers", nil)
 
 	fields, diags := generic.GetManagedFieldSet(obj, fieldManager)

--- a/internal/provider/crd/resource_test.go
+++ b/internal/provider/crd/resource_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/provider"
 	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/provider/crd"
 )
@@ -94,7 +93,6 @@ func TestAccResourceImport(t *testing.T) {
 	}
 
 	configPlanChecks := makeConfigChecks(checkSpeck.Properties, checkSpeck.Outputs)
-	configPlanChecks.PreApply = []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){


### PR DESCRIPTION
This is a bit of a hack, because we assume the field-manager doesn't change underneath us (e.g. due to the resource being deleted/recreated). But I think this is good enough for some testing now.