### PR TITLE
Move properties into `manifest` subfield

### DIFF
--- a/cmd/openapi/main.go
+++ b/cmd/openapi/main.go
@@ -156,11 +156,6 @@ func main() {
 				continue
 			}
 			delete(objectTyp.AttrTypes, "kind")
-			if _, found := objectTyp.AttrTypes["count"]; found {
-				// Count is reserved at top-level in TF schemas. We could rename
-				// it, but skip for now.
-				continue
-			}
 
 			metaTyp, ok := objectTyp.AttrTypes["metadata"].(types.KubernetesObjectType)
 			if !ok {

--- a/internal/generic/schema.go
+++ b/internal/generic/schema.go
@@ -36,7 +36,7 @@ func (t TypeInfo) Interface(client *dynamic.DynamicClient, namespace string) dyn
 	return resource
 }
 
-func OpenApiToTfSchema(ctx context.Context, customType types.KubernetesObjectType, isDatasSource bool) (*schema.Schema, error) {
+func OpenApiToTfSchema(ctx context.Context, customType types.KubernetesObjectType, isDatasSource bool) (schema.Attribute, error) {
 	attributes, err := customType.SchemaAttributes(ctx, types.SchemaOptions{IsDataSource: isDatasSource}, false)
 	if err != nil {
 		return nil, err
@@ -64,5 +64,5 @@ func OpenApiToTfSchema(ctx context.Context, customType types.KubernetesObjectTyp
 	}
 	attributes["metadata"] = meta
 
-	return &schema.Schema{Attributes: attributes}, nil
+	return schema.SingleNestedAttribute{Attributes: attributes, Required: true}, nil
 }

--- a/internal/generic/state.go
+++ b/internal/generic/state.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/types"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,14 +16,14 @@ import (
 )
 
 type PlanOrState interface {
-	Get(ctx context.Context, target interface{}) diag.Diagnostics
+	GetAttribute(ctx context.Context, path path.Path, target interface{}) diag.Diagnostics
 }
 
 func StateToValue(ctx context.Context, state PlanOrState, typeInfo TypeInfo) (types.KubernetesValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var stateValue basetypes.ObjectValue
-	diags.Append(state.Get(ctx, &stateValue)...)
+	diags.Append(state.GetAttribute(ctx, path.Root("manifest"), &stateValue)...)
 	if diags.HasError() {
 		return nil, diags
 	}

--- a/internal/provider/crd/fixtures/calico/data-test.json
+++ b/internal/provider/crd/fixtures/calico/data-test.json
@@ -2,7 +2,7 @@
     "Properties": [
         {
             "Name": "data.k8scrd_ippool_crd_projectcalico_org_v1.foo",
-            "Path": ["spec", "nat_outgoing"],
+            "Path": ["manifest", "spec", "nat_outgoing"],
             "Value": true
         }
     ]

--- a/internal/provider/crd/fixtures/calico/data.tf
+++ b/internal/provider/crd/fixtures/calico/data.tf
@@ -8,8 +8,5 @@ provider "k8scrd" {
 }
 
 data "k8scrd_ippool_crd_projectcalico_org_v1" "foo" {
-  metadata = {
-    name      = "foo"
-    namespace = "default"
-  }
+  manifest = { metadata = { name = "foo", namespace = "default" } }
 }

--- a/internal/provider/crd/fixtures/calico/resources-import-test.json
+++ b/internal/provider/crd/fixtures/calico/resources-import-test.json
@@ -2,10 +2,7 @@
     "Properties": [
         {
             "Name": "k8scrd_ippool_crd_projectcalico_org_v1.baz",
-            "Path": [
-                "spec",
-                "cidr"
-            ],
+            "Path": ["manifest", "spec", "cidr"],
             "Value": "198.51.100.4/30"
         }
     ],

--- a/internal/provider/crd/fixtures/calico/resources-import.tf
+++ b/internal/provider/crd/fixtures/calico/resources-import.tf
@@ -8,10 +8,9 @@ provider "k8scrd" {
 }
 
 resource "k8scrd_ippool_crd_projectcalico_org_v1" "baz" {
-  metadata = { name = "baz" }
-  spec = {
-    cidr         = "198.51.100.4/30"
-    nat_outgoing = false
+  manifest = {
+    metadata = { name = "baz" }
+    spec     = { cidr = "198.51.100.4/30", nat_outgoing = false }
   }
 }
 

--- a/internal/provider/crd/fixtures/calico/resources-test.json
+++ b/internal/provider/crd/fixtures/calico/resources-test.json
@@ -2,10 +2,7 @@
     "Properties": [
         {
             "Name": "k8scrd_ippool_crd_projectcalico_org_v1.bar",
-            "Path": [
-                "spec",
-                "cidr"
-            ],
+            "Path": ["manifest", "spec", "cidr"],
             "Value": "198.51.100.8/30"
         }
     ],

--- a/internal/provider/crd/fixtures/calico/resources.tf
+++ b/internal/provider/crd/fixtures/calico/resources.tf
@@ -8,6 +8,8 @@ provider "k8scrd" {
 }
 
 resource "k8scrd_ippool_crd_projectcalico_org_v1" "bar" {
-  metadata = { name = "bar" }
-  spec     = { cidr = "198.51.100.8/30" }
+  manifest = {
+    metadata = { name = "bar" }
+    spec     = { cidr = "198.51.100.8/30" }
+  }
 }

--- a/internal/provider/crd/fixtures/cert-manager/data-test.json
+++ b/internal/provider/crd/fixtures/cert-manager/data-test.json
@@ -2,12 +2,12 @@
     "Properties": [
         {
             "Name": "data.k8scrd_certificate_certmanager_io_v1.foo",
-            "Path": ["spec", "issuer_ref", "name"],
+            "Path": ["manifest", "spec", "issuer_ref", "name"],
             "Value": "self-signed"
         },
         {
             "Name": "data.k8scrd_issuer_certmanager_io_v1.foo",
-            "Path": ["spec", "acme", "solvers", 0, "dns01", "webhook", "config", "x"],
+            "Path": ["manifest", "spec", "acme", "solvers", 0, "dns01", "webhook", "config", "x"],
             "Value": "x"
         }
     ]

--- a/internal/provider/crd/fixtures/cert-manager/data.tf
+++ b/internal/provider/crd/fixtures/cert-manager/data.tf
@@ -8,9 +8,9 @@ provider "k8scrd" {
 }
 
 data "k8scrd_certificate_certmanager_io_v1" "foo" {
-  metadata = { name = "foo", namespace = "default" }
+  manifest = { metadata = { name = "foo", namespace = "default" } }
 }
 
 data "k8scrd_issuer_certmanager_io_v1" "foo" {
-  metadata = { name = "foo", namespace = "default" }
+  manifest = { metadata = { name = "foo", namespace = "default" } }
 }

--- a/internal/provider/crd/fixtures/cert-manager/resources-import-test.json
+++ b/internal/provider/crd/fixtures/cert-manager/resources-import-test.json
@@ -2,11 +2,7 @@
     "Properties": [
         {
             "Name": "k8scrd_certificate_certmanager_io_v1.baz",
-            "Path": [
-                "spec",
-                "issuer_ref",
-                "name"
-            ],
+            "Path": ["manifest", "spec", "issuer_ref", "name" ],
             "Value": "self-signed"
         }
     ],

--- a/internal/provider/crd/fixtures/cert-manager/resources-import.tf
+++ b/internal/provider/crd/fixtures/cert-manager/resources-import.tf
@@ -8,13 +8,15 @@ provider "k8scrd" {
 }
 
 resource "k8scrd_certificate_certmanager_io_v1" "baz" {
-  metadata = { name = "baz", namespace = "default" }
-  spec = {
-    issuer_ref   = { kind = "ClusterIssuer", name = "self-signed" }
-    dns_names    = ["example.org"]
-    duration     = "2160h"
-    renew_before = "360h"
-    secret_name  = "example-org"
+  manifest = {
+    metadata = { name = "baz", namespace = "default" }
+    spec = {
+      issuer_ref   = { kind = "ClusterIssuer", name = "self-signed" }
+      dns_names    = ["example.org"]
+      duration     = "2160h"
+      renew_before = "360h"
+      secret_name  = "example-org"
+    }
   }
 }
 

--- a/internal/provider/crd/fixtures/cert-manager/resources-test.json
+++ b/internal/provider/crd/fixtures/cert-manager/resources-test.json
@@ -2,11 +2,7 @@
     "Properties": [
         {
             "Name": "k8scrd_certificate_certmanager_io_v1.bar",
-            "Path": [
-                "spec",
-                "issuer_ref",
-                "name"
-            ],
+            "Path": ["manifest", "spec", "issuer_ref", "name"],
             "Value": "self-signed"
         }
     ],

--- a/internal/provider/crd/fixtures/cert-manager/resources.tf
+++ b/internal/provider/crd/fixtures/cert-manager/resources.tf
@@ -8,12 +8,14 @@ provider "k8scrd" {
 }
 
 resource "k8scrd_certificate_certmanager_io_v1" "bar" {
-  metadata = { name = "bar", namespace = "default" }
-  spec = {
-    issuer_ref   = { kind = "ClusterIssuer", name = "self-signed" }
-    dns_names    = ["example.org"]
-    duration     = "2160h"
-    renew_before = "360h"
-    secret_name  = "example-org"
+  manifest = {
+    metadata = { name = "bar", namespace = "default" }
+    spec = {
+      issuer_ref   = { kind = "ClusterIssuer", name = "self-signed" }
+      dns_names    = ["example.org"]
+      duration     = "2160h"
+      renew_before = "360h"
+      secret_name  = "example-org"
+    }
   }
 }

--- a/internal/provider/crd/fixtures/core/data-test.json
+++ b/internal/provider/crd/fixtures/core/data-test.json
@@ -2,17 +2,17 @@
     "Properties": [
         {
             "Name": "data.k8scrd_deployment_apps_v1.foo",
-            "Path": ["spec", "replicas"],
+            "Path": ["manifest", "spec", "replicas"],
             "Value": 0
         },
         {
             "Name": "data.k8scrd_configmap_v1.foo",
-            "Path": ["data", "foo.txt"],
+            "Path": ["manifest", "data", "foo.txt"],
             "Value": "hello, world!\n"
         },
         {
             "Name": "data.k8scrd_namespace_v1.foo",
-            "Path": ["metadata", "name"],
+            "Path": ["manifest", "metadata", "name"],
             "Value": "foo"
         }
     ]

--- a/internal/provider/crd/fixtures/core/data.tf
+++ b/internal/provider/crd/fixtures/core/data.tf
@@ -8,19 +8,13 @@ provider "k8scrd" {
 }
 
 data "k8scrd_deployment_apps_v1" "foo" {
-  metadata = {
-    name      = "foo"
-    namespace = "default"
-  }
+  manifest = { metadata = { name = "foo", namespace = "default" } }
 }
 
 data "k8scrd_configmap_v1" "foo" {
-  metadata = {
-    name      = "foo"
-    namespace = "default"
-  }
+  manifest = { metadata = { name = "foo", namespace = "default" } }
 }
 
 data "k8scrd_namespace_v1" "foo" {
-  metadata = { name = "foo" }
+  manifest = { metadata = { name = "foo" } }
 }

--- a/internal/provider/crd/fixtures/core/resources-import-test.json
+++ b/internal/provider/crd/fixtures/core/resources-import-test.json
@@ -2,18 +2,12 @@
     "Properties": [
         {
             "Name": "k8scrd_deployment_apps_v1.baz",
-            "Path": [
-                "spec",
-                "replicas"
-            ],
+            "Path": ["manifest", "spec", "replicas"],
             "Value": 0
         },
         {
             "Name": "k8scrd_namespace_v1.baz",
-            "Path": [
-                "metadata",
-                "name"
-            ],
+            "Path": ["manifest", "metadata", "name"],
             "Value": "baz"
         }
     ],

--- a/internal/provider/crd/fixtures/core/resources-import.tf
+++ b/internal/provider/crd/fixtures/core/resources-import.tf
@@ -4,25 +4,27 @@ variable "kubeconfig" {
 }
 
 provider "k8scrd" {
-  kubeconfig      = var.kubeconfig
+  kubeconfig = var.kubeconfig
 }
 
 resource "k8scrd_deployment_apps_v1" "baz" {
-  metadata = {
-    name      = "baz"
-    namespace = "default"
-    labels    = { app = "baz" }
-  }
-  spec = {
-    replicas = 0
-    selector = { match_labels = { app = "baz" } }
-    template = {
-      metadata = { labels = { app = "baz" } }
-      spec = {
-        containers = [{
-          name  = "baz"
-          image = "busybox"
-        }]
+  manifest = {
+    metadata = {
+      name      = "baz"
+      namespace = "default"
+      labels    = { app = "baz" }
+    }
+    spec = {
+      replicas = 0
+      selector = { match_labels = { app = "baz" } }
+      template = {
+        metadata = { labels = { app = "baz" } }
+        spec = {
+          containers = [{
+            name  = "baz"
+            image = "busybox"
+          }]
+        }
       }
     }
   }
@@ -34,7 +36,7 @@ import {
 }
 
 resource "k8scrd_namespace_v1" "baz" {
-  metadata = { name = "baz" }
+  manifest = { metadata = { name = "baz" } }
 }
 
 import {

--- a/internal/provider/crd/fixtures/core/resources-test.json
+++ b/internal/provider/crd/fixtures/core/resources-test.json
@@ -2,27 +2,27 @@
     "Properties": [
         {
             "Name": "k8scrd_configmap_v1.bar",
-            "Path": ["data", "foo.txt"],
+            "Path": ["manifest", "data", "foo.txt"],
             "Value": "bar"
         },
         {
             "Name": "k8scrd_deployment_apps_v1.bar",
-            "Path": ["spec", "replicas"],
+            "Path": ["manifest", "spec", "replicas"],
             "Value": 0
         },
         {
             "Name": "k8scrd_deployment_apps_v1.bar",
-            "Path": ["spec", "strategy", "rolling_update", "max_unavailable"],
+            "Path": ["manifest", "spec", "strategy", "rolling_update", "max_unavailable"],
             "Value": 1
         },
         {
             "Name": "k8scrd_namespace_v1.bar",
-            "Path": ["metadata", "name"],
+            "Path": ["manifest", "metadata", "name"],
             "Value": "bar"
         },
         {
             "Name": "k8scrd_clusterrole_rbac_authorization_k8s_io_v1.bar",
-            "Path": ["rules", 0, "verbs", 0],
+            "Path": ["manifest", "rules", 0, "verbs", 0],
             "Value": "get"
         }
     ],

--- a/internal/provider/crd/fixtures/core/resources.tf
+++ b/internal/provider/crd/fixtures/core/resources.tf
@@ -8,52 +8,60 @@ provider "k8scrd" {
 }
 
 resource "k8scrd_deployment_apps_v1" "bar" {
-  metadata = {
-    name      = "bar"
-    namespace = "default"
-    labels    = { app = "bar" }
-  }
-  spec = {
-    replicas = 0
-    selector = { match_labels = { app = "bar" } }
-    strategy = {
-      type = "RollingUpdate"
-      rolling_update = {
-        max_unavailable = 1
-      }
+  manifest = {
+    metadata = {
+      name      = "bar"
+      namespace = "default"
+      labels    = { app = "bar" }
     }
-    template = {
-      metadata = { labels = { app = "bar" } }
-      spec = {
-        containers = [{
-          name  = "foo"
-          image = "busybox"
-        }]
-        volumes = []
+    spec = {
+      replicas = 0
+      selector = { match_labels = { app = "bar" } }
+      strategy = {
+        type = "RollingUpdate"
+        rolling_update = {
+          max_unavailable = 1
+        }
+      }
+      template = {
+        metadata = { labels = { app = "bar" } }
+        spec = {
+          containers = [{
+            name  = "foo"
+            image = "busybox"
+          }]
+          volumes = []
+        }
       }
     }
   }
 }
 
 resource "k8scrd_configmap_v1" "bar" {
-  metadata = {
-    name      = "bar"
-    namespace = "default"
-  }
+  manifest = {
+    metadata = {
+      name      = "bar"
+      namespace = "default"
+    }
 
-  data = { "foo.txt" = "bar" }
+    data = { "foo.txt" = "bar" }
+  }
 }
 
 resource "k8scrd_namespace_v1" "bar" {
-  metadata = {
-    name   = "bar"
-    labels = { "bar" = "bar" }
+  manifest = {
+    metadata = {
+      name   = "bar"
+      labels = { "bar" = "bar" }
+    }
   }
 }
 
 resource "k8scrd_clusterrole_rbac_authorization_k8s_io_v1" "bar" {
-  metadata = { name = "bar" }
-  rules = [
-    { api_groups = [""], resources = ["pods"], verbs = ["get", "list", "watch"] },
-  ]
+  manifest = {
+    metadata = { name = "bar" }
+    rules = [
+      { api_groups = [""], resources = ["pods"], verbs = ["get", "list", "watch"] },
+    ]
+  }
 }

--- a/internal/provider/crd/fixtures/example.com/data-test.json
+++ b/internal/provider/crd/fixtures/example.com/data-test.json
@@ -2,7 +2,7 @@
     "Properties": [
         {
             "Name": "data.k8scrd_foo_example_com_v1.foo",
-            "Path": ["spec", "foo"],
+            "Path": ["manifest", "spec", "foo"],
             "Value": "foo"
         }
     ]

--- a/internal/provider/crd/fixtures/example.com/data.tf
+++ b/internal/provider/crd/fixtures/example.com/data.tf
@@ -8,8 +8,5 @@ provider "k8scrd" {
 }
 
 data "k8scrd_foo_example_com_v1" "foo" {
-  metadata = {
-    name      = "foo"
-    namespace = "default"
-  }
+  manifest = { metadata = { name = "foo", namespace = "default" } }
 }

--- a/internal/provider/crd/fixtures/example.com/resources-import-test.json
+++ b/internal/provider/crd/fixtures/example.com/resources-import-test.json
@@ -2,10 +2,7 @@
     "Properties": [
         {
             "Name": "k8scrd_foo_example_com_v1.baz",
-            "Path": [
-                "spec",
-                "foo"
-            ],
+            "Path": ["manifest", "spec", "foo"],
             "Value": "baz"
         }
     ],

--- a/internal/provider/crd/fixtures/example.com/resources-import.tf
+++ b/internal/provider/crd/fixtures/example.com/resources-import.tf
@@ -8,11 +8,10 @@ provider "k8scrd" {
 }
 
 resource "k8scrd_foo_example_com_v1" "baz" {
-  metadata = {
-    name      = "baz"
-    namespace = "default"
+  manifest = {
+    metadata = { name = "baz", namespace = "default" }
+    spec     = { foo = "baz" }
   }
-  spec = { foo = "baz" }
 }
 
 import {

--- a/internal/provider/crd/fixtures/example.com/resources-test.json
+++ b/internal/provider/crd/fixtures/example.com/resources-test.json
@@ -2,12 +2,12 @@
     "Properties": [
         {
             "Name": "k8scrd_foo_example_com_v1.bar",
-            "Path": ["spec", "foo"],
+            "Path": ["manifest", "spec", "foo"],
             "Value": "bar"
         },
         {
             "Name": "k8scrd_bar_example_com_v1.bar",
-            "Path": ["spec", "bar"],
+            "Path": ["manifest", "spec", "bar"],
             "Value": "bar"
         }
     ],

--- a/internal/provider/crd/fixtures/example.com/resources.tf
+++ b/internal/provider/crd/fixtures/example.com/resources.tf
@@ -8,17 +8,15 @@ provider "k8scrd" {
 }
 
 resource "k8scrd_foo_example_com_v1" "bar" {
-  metadata = {
-    name      = "bar"
-    namespace = "default"
+  manifest = {
+    metadata = { name = "bar", namespace = "default" }
+    spec     = { foo = "bar" }
   }
-  spec = { foo = "bar" }
 }
 
 resource "k8scrd_bar_example_com_v1" "bar" {
-  metadata = {
-    name      = "bar"
-    namespace = "default"
+  manifest = {
+    metadata = { name = "bar", namespace = "default" }
+    spec     = { bar = "bar" }
   }
-  spec = { bar = "bar" }
 }

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -33,7 +33,6 @@ func NewResource(typeInfo generic.TypeInfo) tfresource.Resource {
 			AttrTypes: maps.Clone(typeInfo.Schema.AttrTypes),
 		},
 		FieldNames:     typeInfo.Schema.FieldNames,
-		InternalFields: typeInfo.Schema.InternalFields,
 		RequiredFields: typeInfo.Schema.RequiredFields,
 	}
 
@@ -44,10 +43,7 @@ func NewResource(typeInfo generic.TypeInfo) tfresource.Resource {
 		},
 		FieldNames:     maps.Clone(metadata.FieldNames),
 		RequiredFields: maps.Clone(metadata.RequiredFields),
-		InternalFields: maps.Clone(metadata.InternalFields),
 	}
-	metadata.AttrTypes["field_manager"] = basetypes.StringType{}
-	metadata.InternalFields["field_manager"] = true
 	schema.AttrTypes["metadata"] = metadata
 
 	return &crdResource{typeInfo: generic.TypeInfo{

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/generic"
-	"github.com/kwohlfahrt/terraform-provider-k8scrd/internal/types"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,32 +25,7 @@ type crdResource struct {
 }
 
 func NewResource(typeInfo generic.TypeInfo) tfresource.Resource {
-	schema := types.KubernetesObjectType{
-		ObjectType: basetypes.ObjectType{
-			AttrTypes: maps.Clone(typeInfo.Schema.AttrTypes),
-		},
-		FieldNames:     typeInfo.Schema.FieldNames,
-		RequiredFields: typeInfo.Schema.RequiredFields,
-	}
-
-	metadata := schema.AttrTypes["metadata"].(types.KubernetesObjectType)
-	metadata = types.KubernetesObjectType{
-		ObjectType: basetypes.ObjectType{
-			AttrTypes: maps.Clone(metadata.AttrTypes),
-		},
-		FieldNames:     maps.Clone(metadata.FieldNames),
-		RequiredFields: maps.Clone(metadata.RequiredFields),
-	}
-	schema.AttrTypes["metadata"] = metadata
-
-	return &crdResource{typeInfo: generic.TypeInfo{
-		Group:      typeInfo.Group,
-		Resource:   typeInfo.Resource,
-		Kind:       typeInfo.Kind,
-		Version:    typeInfo.Version,
-		Namespaced: typeInfo.Namespaced,
-		Schema:     schema,
-	}}
+	return &crdResource{typeInfo: typeInfo}
 }
 
 func (c *crdResource) Metadata(ctx context.Context, req tfresource.MetadataRequest, resp *tfresource.MetadataResponse) {

--- a/internal/types/object_test.go
+++ b/internal/types/object_test.go
@@ -46,7 +46,7 @@ func TestRequiredFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := result.Attributes["spec"].(schema.SingleNestedAttribute)
+	spec := result.(schema.SingleNestedAttribute).Attributes["spec"].(schema.SingleNestedAttribute)
 	if !spec.Attributes["foo"].IsRequired() {
 		t.Error("Expected attribute spec.foo to be required")
 	}
@@ -60,7 +60,7 @@ func TestFieldType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := result.Attributes["spec"].(schema.SingleNestedAttribute)
+	spec := result.(schema.SingleNestedAttribute).Attributes["spec"].(schema.SingleNestedAttribute)
 	if _, ok := spec.Attributes["foo"].(schema.StringAttribute); !ok {
 		t.Error("Expected attribute spec.foo to be string attribute")
 	}


### PR DESCRIPTION
To avoid clashes with reserved arguments, e.g. `provider` for storage classes.