### PR TITLE
Enforce uniqueness on object creation

### DIFF
--- a/internal/provider/crd/fixtures/example.com/fail.tf
+++ b/internal/provider/crd/fixtures/example.com/fail.tf
@@ -1,0 +1,22 @@
+variable "kubeconfig" {
+  type      = string
+  sensitive = true
+}
+
+provider "k8scrd" {
+  kubeconfig = var.kubeconfig
+}
+
+resource "k8scrd_foo_example_com_v1" "qux-0" {
+  manifest = {
+    metadata = { name = "qux", namespace = "default" }
+    spec     = { foo = "qux" }
+  }
+}
+
+resource "k8scrd_foo_example_com_v1" "qux-1" {
+  manifest = {
+    metadata = { name = "qux", namespace = "default" }
+    spec     = { foo = "qux" }
+  }
+}

--- a/internal/provider/crd/fixtures/example.com/resources.tf
+++ b/internal/provider/crd/fixtures/example.com/resources.tf
@@ -3,6 +3,11 @@ variable "kubeconfig" {
   sensitive = true
 }
 
+variable "update" {
+  type    = bool
+  default = false
+}
+
 provider "k8scrd" {
   kubeconfig = var.kubeconfig
 }
@@ -17,7 +22,7 @@ resource "k8scrd_foo_example_com_v1" "bar" {
 resource "k8scrd_bar_example_com_v1" "bar" {
   manifest = {
     metadata = { name = "bar", namespace = "default" }
-    spec     = { bar = "bar" }
+    spec     = { bar = var.update ? "barbar" : "bar" }
   }
 }
 

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -15,8 +15,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/csaupgrade"
 )
 
 type crdResource struct {
@@ -99,12 +102,12 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 		return
 	}
 
-	// TODO: Validate that we haven't previously created the object. It will
-	// conflict fail if it was created by a different tool, but if we created it
-	// and forgot, this will silently adopt the object. We could generate a
-	// unique `FieldManager` ID per resource, and persist it in the TF state.
-	obj, err := c.typeInfo.Interface(c.client, meta.Namespace).
-		Apply(ctx, meta.Name, planObj, metav1.ApplyOptions{FieldManager: fieldManager})
+	iface := c.typeInfo.Interface(c.client, meta.Namespace)
+	// Use a `Create` operation, to ensure we are creating the resource.  This
+	// ensures two terraform operations can't both create the same object. See
+	// also github.com/kubernetes/kubernetes#116156
+	obj, err := iface.
+		Create(ctx, planObj, metav1.CreateOptions{FieldManager: fieldManager})
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create resource", err.Error())
 		return
@@ -126,6 +129,21 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
+
+	// We have created the object, so all fields are owned by `fieldManager`,
+	// but with `operation: Update`. This produces a conflict when we try to
+	// server-side apply changes in `Update()`. Use `csaupgrade` to migrate the
+	// field manager to `operation: Apply`. This might be better in `Update()`.
+	patchData, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(fieldManager), fieldManager)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to construct field-manager patch", err.Error())
+		return
+	}
+
+	_, err = iface.Patch(ctx, meta.Name, k8stypes.JSONPatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to patch field-manager", err.Error())
+	}
 }
 
 func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp *tfresource.ReadResponse) {

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/csaupgrade"
+	"k8s.io/client-go/util/retry"
 )
 
 type crdResource struct {
@@ -113,6 +114,37 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 		return
 	}
 
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// We have created the object, so all fields are owned by `fieldManager`,
+		// but with `operation: Update`. This produces a conflict when we try to
+		// server-side apply changes in `Update()`. Use `csaupgrade` to migrate the
+		// field manager to `operation: Apply`. This might be better in `Update()`.
+		patchData, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(fieldManager), fieldManager)
+		if err != nil {
+			return err
+		}
+
+		obj, err = iface.Patch(ctx, meta.Name, k8stypes.JSONPatchType, patchData, metav1.PatchOptions{})
+		if err != nil && errors.IsConflict(err) {
+			newObj, getErr := iface.Get(ctx, meta.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			obj = newObj
+		}
+		return err
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to patch field-manager", err.Error())
+		return
+	}
+
+	// Apply to update the list of tracked fields to match `planObj`, not the entire object creation.
+	obj, err = iface.Apply(ctx, meta.Name, planObj, metav1.ApplyOptions{FieldManager: fieldManager})
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to update resource", err.Error())
+	}
+
 	fields, diags := generic.GetManagedFieldSet(obj, fieldManager)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
@@ -129,21 +161,6 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
-
-	// We have created the object, so all fields are owned by `fieldManager`,
-	// but with `operation: Update`. This produces a conflict when we try to
-	// server-side apply changes in `Update()`. Use `csaupgrade` to migrate the
-	// field manager to `operation: Apply`. This might be better in `Update()`.
-	patchData, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(fieldManager), fieldManager)
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to construct field-manager patch", err.Error())
-		return
-	}
-
-	_, err = iface.Patch(ctx, meta.Name, k8stypes.JSONPatchType, patchData, metav1.PatchOptions{})
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to patch field-manager", err.Error())
-	}
 }
 
 func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp *tfresource.ReadResponse) {
@@ -235,7 +252,7 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 	obj, err := c.typeInfo.Interface(c.client, meta.Namespace).
 		Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: fieldManager, Force: c.forceConflicts})
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to create resource", err.Error())
+		resp.Diagnostics.AddError("Unable to update resource", err.Error())
 		return
 	}
 

--- a/internal/provider/crd/resource_test.go
+++ b/internal/provider/crd/resource_test.go
@@ -54,6 +54,13 @@ func TestAccResource(t *testing.T) {
 			Check:            makeChecks(k, checkSpeck.Resources),
 			ConfigPlanChecks: makeConfigChecks(checkSpeck.Properties, checkSpeck.Outputs),
 		},
+		{
+			Config: string(cfg),
+			ConfigVariables: config.Variables{
+				"kubeconfig": config.StringVariable(string(kubeconfig)),
+				"update":     config.BoolVariable(true),
+			},
+		},
 	}
 
 	failCfg, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/fail.tf", os.Getenv("PROVIDER")))

--- a/internal/provider/crd/resource_test.go
+++ b/internal/provider/crd/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -46,6 +47,28 @@ func TestAccResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	steps := []resource.TestStep{
+		{
+			Config:           string(cfg),
+			ConfigVariables:  config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
+			Check:            makeChecks(k, checkSpeck.Resources),
+			ConfigPlanChecks: makeConfigChecks(checkSpeck.Properties, checkSpeck.Outputs),
+		},
+	}
+
+	failCfg, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/fail.tf", os.Getenv("PROVIDER")))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+	} else {
+		steps = append(steps, resource.TestStep{
+			Config:          string(failCfg),
+			ConfigVariables: config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
+			ExpectError:     regexp.MustCompile("metadata.resourceVersion"),
+		})
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"k8scrd": providerserver.NewProtocol6WithError(providerFactory()),
@@ -57,14 +80,7 @@ func TestAccResource(t *testing.T) {
 				t.Fatal(err)
 			}
 		},
-		Steps: []resource.TestStep{
-			{
-				Config:           string(cfg),
-				ConfigVariables:  config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
-				Check:            makeChecks(k, checkSpeck.Resources),
-				ConfigPlanChecks: makeConfigChecks(checkSpeck.Properties, checkSpeck.Outputs),
-			},
-		},
+		Steps:        steps,
 		CheckDestroy: makeDestroyChecks(k, checkSpeck.Resources),
 	})
 }

--- a/internal/provider/crd/resource_test.go
+++ b/internal/provider/crd/resource_test.go
@@ -72,7 +72,7 @@ func TestAccResource(t *testing.T) {
 		steps = append(steps, resource.TestStep{
 			Config:          string(failCfg),
 			ConfigVariables: config.Variables{"kubeconfig": config.StringVariable(string(kubeconfig))},
-			ExpectError:     regexp.MustCompile("metadata.resourceVersion"),
+			ExpectError:     regexp.MustCompile("already exists"),
 		})
 	}
 


### PR DESCRIPTION
Previously, we don't enforce that a create operation is actually creating the object. This means Terraform can think two separate resources own an underlying k8s resource.