### PR TITLE
Build GitHub pages

### DIFF
--- a/.github/workflows/registry.yaml
+++ b/.github/workflows/registry.yaml
@@ -1,0 +1,51 @@
+name: Update registry
+
+on:
+  push:
+    branches: [pages]
+  workflow_dispatch: {}
+  workflow_call: {}
+
+# Serialize runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/configure-pages@v5
+      - run: mkdir ./pages
+      - name: build
+        working-directory: ./pages
+        run: |
+          mkdir -p ./.well-known
+          cat <<EOF > ./.well-known/terraform.json
+          {"providers.v1": "https://kwohlfahrt.github.io/tf-k8s/registry/v1/"}
+          EOF
+      # upload pages artifact ignores hidden directories, but we need .well-known.
+      - run: tar -cvf "${{ runner.temp }}/artifact.tar" .
+        working-directory: ./pages
+      - uses: actions/upload-artifact@v4
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    if: github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
Initial PR for a pages-hosted registry. This enables the workflow on `main`.