### PR TITLE
Track field manager state

### DIFF
--- a/internal/generic/state.go
+++ b/internal/generic/state.go
@@ -3,8 +3,6 @@ package generic
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -46,33 +44,6 @@ func StateToObjectMeta(ctx context.Context, state PlanOrState, typeInfo TypeInfo
 	}
 
 	return diags
-}
-
-type PrivateState interface {
-	GetKey(ctx context.Context, key string) ([]byte, diag.Diagnostics)
-}
-
-func GetImportFieldManager(ctx context.Context, private PrivateState, key string) (*string, diag.Diagnostics) {
-	serialized, diags := private.GetKey(ctx, key)
-	if diags.HasError() || serialized == nil {
-		return nil, diags
-	}
-
-	fieldManagers := make([]string, 0)
-	err := json.Unmarshal(serialized, &fieldManagers)
-	if err != nil {
-		diags.AddError("Error unmarshalling import field managers", fmt.Sprintf("expected valid JSON, got %v", serialized))
-		return nil, diags
-	}
-
-	if len(fieldManagers) != 1 {
-		diags.AddError(
-			"Too many field managers for import",
-			fmt.Sprintf("Only one field manager is supported for import, got %v", fieldManagers),
-		)
-	}
-
-	return &fieldManagers[0], diags
 }
 
 var defaultFields fieldpath.Set

--- a/internal/provider/crd/fixtures/core/test.tf
+++ b/internal/provider/crd/fixtures/core/test.tf
@@ -51,6 +51,8 @@ resource "k8s_deployment_apps_v1" "bar" {
             { name = "foo", image = "busybox" },
             { name = "ubuntu", image = "ubuntu:22.04", liveness_probe = { http_get = { port = "healthz" } } },
           ]
+          # k8s doesn't include an empty volumes field in `managedFields`. Test
+          # that we handle this properly.
           volumes = []
         }
       }

--- a/internal/provider/crd/fixtures/core/test.tf
+++ b/internal/provider/crd/fixtures/core/test.tf
@@ -134,7 +134,11 @@ resource "k8s_clusterrolebinding_rbac_authorization_k8s_io_v1" "baz" {
       kind      = "ClusterRole"
       name      = "system:node"
     }
+    subjects = []
   }
+  # Required due to migration not working for some empty fields. See
+  # kubernetes/kubernetes#128924.
+  force_conflicts = true
 }
 
 import {

--- a/internal/provider/crd/fixtures/example/test.tf
+++ b/internal/provider/crd/fixtures/example/test.tf
@@ -36,6 +36,7 @@ resource "k8s_bar_example_com_v1" "bar" {
     metadata = { name = "bar", namespace = "default" }
     spec     = { bar = var.update ? "barbar" : "bar" }
   }
+  field_manager = var.update ? "tofu-k8s" : "not-tofu-k8s"
 }
 
 resource "k8s_foo_example_com_v1" "baz" {

--- a/internal/provider/crd/fixtures/example/test.tf
+++ b/internal/provider/crd/fixtures/example/test.tf
@@ -41,7 +41,7 @@ resource "k8s_bar_example_com_v1" "bar" {
 resource "k8s_foo_example_com_v1" "baz" {
   manifest = {
     metadata = { name = "baz", namespace = "default" }
-    spec     = { foo = "baz" }
+    spec     = { foo = var.update ? "bazbaz" : "baz" }
   }
 }
 

--- a/internal/provider/crd/provider.go
+++ b/internal/provider/crd/provider.go
@@ -15,8 +15,7 @@ import (
 )
 
 type Clients struct {
-	dynamic        *dynamic.DynamicClient
-	forceConflicts bool
+	dynamic *dynamic.DynamicClient
 }
 
 type CrdProvider struct {
@@ -25,8 +24,7 @@ type CrdProvider struct {
 }
 
 type CrdProviderModel struct {
-	Kubeconfig     types.String `tfsdk:"kubeconfig"`
-	ForceConflicts types.Bool   `tfsdk:"force_conflicts"`
+	Kubeconfig types.String `tfsdk:"kubeconfig"`
 }
 
 func (p *CrdProvider) Metadata(ctx context.Context, req tfprovider.MetadataRequest, resp *tfprovider.MetadataResponse) {
@@ -40,10 +38,6 @@ func (p *CrdProvider) Schema(ctx context.Context, req tfprovider.SchemaRequest, 
 			"kubeconfig": schema.StringAttribute{
 				MarkdownDescription: "Kubernetes Configuration",
 				Required:            true,
-			},
-			"force_conflicts": schema.BoolAttribute{
-				MarkdownDescription: "Force field conflicts",
-				Optional:            true,
 			},
 		},
 	}
@@ -62,10 +56,7 @@ func (p *CrdProvider) Configure(ctx context.Context, req tfprovider.ConfigureReq
 		return
 	}
 
-	clients := Clients{
-		dynamic:        dynamic,
-		forceConflicts: data.ForceConflicts.ValueBool(),
-	}
+	clients := Clients{dynamic: dynamic}
 	resp.DataSourceData = clients
 	resp.ResourceData = clients
 }

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -2,7 +2,6 @@ package crd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -51,14 +50,18 @@ func (c *crdResource) Metadata(ctx context.Context, req tfresource.MetadataReque
 	resp.TypeName = typeName(req.ProviderTypeName, c.typeInfo)
 }
 
+const defaultFieldManager string = "tofu-k8scrd"
+
 func (c *crdResource) Schema(ctx context.Context, req tfresource.SchemaRequest, resp *tfresource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"manifest": generic.OpenApiToTfSchema(ctx, c.typeInfo, false),
 			"field_manager": schema.StringAttribute{
 				Required: false,
+				Optional: true,
 				Computed: true,
-				Default:  stringdefault.StaticString(fieldManager),
+				Default:  stringdefault.StaticString(defaultFieldManager),
 			},
 		},
 	}
@@ -82,11 +85,15 @@ func (c *crdResource) Configure(ctx context.Context, req tfresource.ConfigureReq
 	c.forceConflicts = clients.forceConflicts
 }
 
-const fieldManager string = "tofu-k8scrd"
-
 func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, resp *tfresource.CreateResponse) {
 	var meta generic.ObjectMeta
 	resp.Diagnostics.Append(generic.StateToObjectMeta(ctx, req.Plan, c.typeInfo, &meta)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var fieldManager string
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("field_manager"), &fieldManager)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -173,9 +180,9 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	importFieldManager, diags := generic.GetImportFieldManager(ctx, req.Private, "import-field-managers")
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
+	var fieldManager string
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("field_manager"), &fieldManager)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -187,87 +194,6 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 		}
 		resp.Diagnostics.AddError("Unable to fetch resource", err.Error())
 		return
-	}
-
-	readFieldManager := fieldManager
-	if importFieldManager != nil {
-		readFieldManager = *importFieldManager
-	}
-
-	fields, diags := generic.GetManagedFieldSet(obj, readFieldManager)
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
-		return
-	}
-	resp.Diagnostics.Append(state.ManagedFields(ctx, path.Empty(), fields, nil)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields.Leaves(), &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
-	if importFieldManager != nil {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), importFieldManager)...)
-	} else {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
-	}
-}
-
-func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, resp *tfresource.UpdateResponse) {
-	var meta generic.ObjectMeta
-	resp.Diagnostics.Append(generic.StateToObjectMeta(ctx, req.State, c.typeInfo, &meta)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	var state types.KubernetesObjectValue
-	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("manifest"), &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	importFieldManager, diags := generic.GetImportFieldManager(ctx, req.Private, "import-field-managers")
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
-		return
-	}
-
-	obj, diags := generic.ValueToUnstructured(ctx, state, c.typeInfo)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// TODO: Validate that the object already exists. This will silently create
-	// the object if it does not already exist.
-	obj, err := c.typeInfo.Interface(c.client, meta.Namespace).
-		Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: fieldManager, Force: c.forceConflicts})
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to update resource", err.Error())
-		return
-	}
-
-	if importFieldManager != nil && *importFieldManager != fieldManager {
-		empty := unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": c.typeInfo.GroupVersionResource().GroupVersion().String(),
-			"kind":       c.typeInfo.Kind,
-			"metadata":   map[string]interface{}{"name": meta.Name, "namespace": meta.Namespace},
-		}}
-		_, err := c.typeInfo.Interface(c.client, meta.Namespace).
-			Apply(ctx, meta.Name, &empty, metav1.ApplyOptions{FieldManager: *importFieldManager})
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to remove imported fieldManager", err.Error())
-			return
-		}
-		resp.Private.SetKey(ctx, "import-field-managers", nil)
 	}
 
 	fields, diags := generic.GetManagedFieldSet(obj, fieldManager)
@@ -284,8 +210,83 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
+}
+
+func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, resp *tfresource.UpdateResponse) {
+	var meta generic.ObjectMeta
+	resp.Diagnostics.Append(generic.StateToObjectMeta(ctx, req.State, c.typeInfo, &meta)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state types.KubernetesObjectValue
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("manifest"), &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var fieldManager string
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("field_manager"), &fieldManager)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var planFieldManager string
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("field_manager"), &planFieldManager)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	obj, diags := generic.ValueToUnstructured(ctx, state, c.typeInfo)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO: Validate that the object already exists. This will silently create
+	// the object if it does not already exist.
+	obj, err := c.typeInfo.Interface(c.client, meta.Namespace).
+		Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: planFieldManager, Force: c.forceConflicts})
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to update resource", err.Error())
+		return
+	}
+
+	if fieldManager != planFieldManager {
+		empty := unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": c.typeInfo.GroupVersionResource().GroupVersion().String(),
+			"kind":       c.typeInfo.Kind,
+			"metadata":   map[string]interface{}{"name": meta.Name, "namespace": meta.Namespace},
+		}}
+		_, err := c.typeInfo.Interface(c.client, meta.Namespace).
+			Apply(ctx, meta.Name, &empty, metav1.ApplyOptions{FieldManager: fieldManager})
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to remove imported fieldManager", err.Error())
+			return
+		}
+	}
+
+	fields, diags := generic.GetManagedFieldSet(obj, defaultFieldManager)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(state.ManagedFields(ctx, path.Empty(), fields, nil)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(generic.UnstructuredToValue(ctx, c.typeInfo.Schema, *obj, fields.Leaves(), &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), defaultFieldManager)...)
 }
 
 func (c *crdResource) Delete(ctx context.Context, req tfresource.DeleteRequest, resp *tfresource.DeleteResponse) {
@@ -318,26 +319,27 @@ func (c *crdResource) Delete(ctx context.Context, req tfresource.DeleteRequest, 
 }
 
 func (c *crdResource) ImportState(ctx context.Context, req tfresource.ImportStateRequest, resp *tfresource.ImportStateResponse) {
+	var expectedFormat string
+	if c.typeInfo.Namespaced {
+		expectedFormat = "fieldManager:namespace/name"
+	} else {
+		expectedFormat = "fieldManager:name"
+	}
+
 	components := strings.SplitN(req.ID, ":", 2)
 	if len(components) != 2 {
-		resp.Diagnostics.AddError("Invalid import ID", fmt.Sprintf("expected fieldManagers:resource import, got %s", req.ID))
+		resp.Diagnostics.AddError("Invalid import ID", fmt.Sprintf("expected %s import, got %s", expectedFormat, req.ID))
 		return
 	}
 
-	fieldManagers := strings.Split(components[0], ",")
+	fieldManager := components[0]
 	resource := components[1]
 
-	fieldManagerState, err := json.Marshal(fieldManagers)
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to marshal fieldManagers", err.Error())
-		return
-	}
-
-	metadata := make(map[string]interface{})
+	metadata := make(map[string]any)
 	if c.typeInfo.Namespaced {
 		components = strings.SplitN(resource, "/", 2)
 		if len(components) != 2 {
-			resp.Diagnostics.AddError("Invalid import ID", fmt.Sprintf("expected namespace/name resource, got %s", resource))
+			resp.Diagnostics.AddError("Invalid import ID", fmt.Sprintf("expected %s resource, got %s", expectedFormat, resource))
 			return
 		}
 		metadata["namespace"] = components[0]
@@ -346,7 +348,7 @@ func (c *crdResource) ImportState(ctx context.Context, req tfresource.ImportStat
 		metadata["name"] = resource
 	}
 
-	obj := unstructured.Unstructured{Object: map[string]interface{}{"metadata": metadata}}
+	obj := unstructured.Unstructured{Object: map[string]any{"metadata": metadata}}
 	var state types.KubernetesObjectValue
 	resp.Diagnostics.Append(generic.UnstructuredToValue(ctx, c.typeInfo.Schema, obj, nil, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -354,7 +356,7 @@ func (c *crdResource) ImportState(ctx context.Context, req tfresource.ImportStat
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
-	resp.Private.SetKey(ctx, "import-field-managers", fieldManagerState)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
 }
 
 func (c *crdResource) MoveState(ctx context.Context) []tfresource.StateMover {
@@ -366,7 +368,8 @@ func (c *crdResource) MoveState(ctx context.Context) []tfresource.StateMover {
 				"field_manager": schema.StringAttribute{
 					Required: false,
 					Computed: true,
-					Default:  stringdefault.StaticString(fieldManager),
+					Optional: true,
+					Default:  stringdefault.StaticString(defaultFieldManager),
 				},
 			},
 		},

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -226,11 +226,6 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	var state types.KubernetesObjectValue
-	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("manifest"), &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 	var fieldManager string
 	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("field_manager"), &fieldManager)...)
 	if resp.Diagnostics.HasError() {
@@ -242,6 +237,43 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		return
 	}
 
+	if fieldManager != planFieldManager {
+		var oldState types.KubernetesObjectValue
+		resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("manifest"), &oldState)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		obj, diags := generic.ValueToUnstructured(ctx, oldState, c.typeInfo)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		_, err := c.typeInfo.Interface(c.client, meta.Namespace).
+			Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: planFieldManager})
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to apply new fieldManager", err.Error())
+			return
+		}
+
+		empty := unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": c.typeInfo.GroupVersionResource().GroupVersion().String(),
+			"kind":       c.typeInfo.Kind,
+			"metadata":   map[string]interface{}{"name": meta.Name, "namespace": meta.Namespace},
+		}}
+		_, err = c.typeInfo.Interface(c.client, meta.Namespace).
+			Apply(ctx, meta.Name, &empty, metav1.ApplyOptions{FieldManager: fieldManager})
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to remove old fieldManager", err.Error())
+			return
+		}
+	}
+
+	var state types.KubernetesObjectValue
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("manifest"), &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	obj, diags := generic.ValueToUnstructured(ctx, state, c.typeInfo)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -257,21 +289,7 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		return
 	}
 
-	if fieldManager != planFieldManager {
-		empty := unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": c.typeInfo.GroupVersionResource().GroupVersion().String(),
-			"kind":       c.typeInfo.Kind,
-			"metadata":   map[string]interface{}{"name": meta.Name, "namespace": meta.Namespace},
-		}}
-		_, err := c.typeInfo.Interface(c.client, meta.Namespace).
-			Apply(ctx, meta.Name, &empty, metav1.ApplyOptions{FieldManager: fieldManager})
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to remove imported fieldManager", err.Error())
-			return
-		}
-	}
-
-	fields, diags := generic.GetManagedFieldSet(obj, defaultFieldManager)
+	fields, diags := generic.GetManagedFieldSet(obj, planFieldManager)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
@@ -286,7 +304,7 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), defaultFieldManager)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), planFieldManager)...)
 }
 
 func (c *crdResource) Delete(ctx context.Context, req tfresource.DeleteRequest, resp *tfresource.DeleteResponse) {

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/kwohlfahrt/tf-k8s/internal/generic"
 	"github.com/kwohlfahrt/tf-k8s/internal/types"
@@ -23,9 +24,8 @@ import (
 )
 
 type crdResource struct {
-	typeInfo       generic.TypeInfo
-	client         *dynamic.DynamicClient
-	forceConflicts bool
+	typeInfo generic.TypeInfo
+	client   *dynamic.DynamicClient
 }
 
 func NewResource(typeInfo generic.TypeInfo) tfresource.Resource {
@@ -63,6 +63,12 @@ func (c *crdResource) Schema(ctx context.Context, req tfresource.SchemaRequest, 
 				Computed: true,
 				Default:  stringdefault.StaticString(defaultFieldManager),
 			},
+			"force_conflicts": schema.BoolAttribute{
+				Required: false,
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
 		},
 	}
 }
@@ -82,7 +88,6 @@ func (c *crdResource) Configure(ctx context.Context, req tfresource.ConfigureReq
 		return
 	}
 	c.client = clients.dynamic
-	c.forceConflicts = clients.forceConflicts
 }
 
 func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, resp *tfresource.CreateResponse) {
@@ -91,9 +96,13 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	var fieldManager string
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("field_manager"), &fieldManager)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var forceConflicts *bool
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("force_conflicts"), &forceConflicts)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -167,6 +176,7 @@ func (c *crdResource) Create(ctx context.Context, req tfresource.CreateRequest, 
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("force_conflicts"), forceConflicts)...)
 }
 
 func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp *tfresource.ReadResponse) {
@@ -182,6 +192,11 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 	}
 	var fieldManager string
 	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("field_manager"), &fieldManager)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var forceConflicts *bool
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("force_conflicts"), &forceConflicts)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -213,6 +228,7 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("force_conflicts"), forceConflicts)...)
 }
 
 func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, resp *tfresource.UpdateResponse) {
@@ -231,6 +247,11 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var forceConflicts *bool
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("force_conflicts"), &forceConflicts)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if fieldManager != planFieldManager {
 		var oldState types.KubernetesObjectValue
@@ -245,7 +266,7 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 		}
 
 		_, err := c.typeInfo.Interface(c.client, meta.Namespace).
-			Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: planFieldManager})
+			Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: planFieldManager, Force: *forceConflicts})
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to apply new fieldManager", err.Error())
 			return
@@ -278,7 +299,7 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 	// TODO: Validate that the object already exists. This will silently create
 	// the object if it does not already exist.
 	obj, err := c.typeInfo.Interface(c.client, meta.Namespace).
-		Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: planFieldManager, Force: c.forceConflicts})
+		Apply(ctx, meta.Name, obj, metav1.ApplyOptions{FieldManager: planFieldManager, Force: *forceConflicts})
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to update resource", err.Error())
 		return
@@ -300,6 +321,7 @@ func (c *crdResource) Update(ctx context.Context, req tfresource.UpdateRequest, 
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), planFieldManager)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("force_conflicts"), forceConflicts)...)
 }
 
 func (c *crdResource) Delete(ctx context.Context, req tfresource.DeleteRequest, resp *tfresource.DeleteResponse) {
@@ -383,6 +405,12 @@ func (c *crdResource) MoveState(ctx context.Context) []tfresource.StateMover {
 					Computed: true,
 					Optional: true,
 					Default:  stringdefault.StaticString(defaultFieldManager),
+				},
+				"force_conflicts": schema.BoolAttribute{
+					Required: false,
+					Computed: true,
+					Optional: true,
+					Default:  booldefault.StaticBool(false),
 				},
 			},
 		},

--- a/internal/provider/crd/resource.go
+++ b/internal/provider/crd/resource.go
@@ -211,11 +211,6 @@ func (c *crdResource) Read(ctx context.Context, req tfresource.ReadRequest, resp
 		return
 	}
 
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manifest"), state)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("field_manager"), fieldManager)...)
 }

--- a/internal/provider/crd/resource_test.go
+++ b/internal/provider/crd/resource_test.go
@@ -129,6 +129,12 @@ func patchState(wd string) error {
 		if typ, isK8s := strings.CutPrefix(typ, "k8s_"); isK8s {
 			resource["type"] = "k8scrd_" + typ
 		}
+		instances := resource["instances"].([]any)
+		for _, instance := range instances {
+			instance := instance.(map[string]any)
+			attributes := instance["attributes"].(map[string]any)
+			delete(attributes, "force_conflicts")
+		}
 	}
 
 	rawState, err = json.Marshal(state)


### PR DESCRIPTION
We want to support changing the `field_manager` value, so track it explicitly in the state.

This removes support for importing from >1 field manager, which was never tested.